### PR TITLE
Refactor: 보스레이드 시작 및 종료 로직 수정, raidStatus 만료시간 설정

### DIFF
--- a/controllers/bossRaid.controller.js
+++ b/controllers/bossRaid.controller.js
@@ -28,33 +28,30 @@ class BossRaidController {
      * 기능: 보스레이드 게임 시작
      * 작성자: 이승연
      */
-    const { userId, level } = req.body;
-    const [data] = await BossRaidService.createId(userId, level); // raidRecordId 생성
-    const raidRecordId = data.insertId;
     let isEntered = false;
-
     try { // Redis에서 raidStatus가 있으면 이미 사용중이므로 게임 시작이 불가능하고 반대의 경우 게임 시작이 가능하다
       let raidStatus = await BossRaidService.bossRaidStatus();
       if (raidStatus) { // 게임 시작 불가능
-        isEntered = true;
         return res.status(400).json({
           message: "이미 게임중인 사용자가 있습니다.",
           isEntered,
         });
       } else { // 게임 시작 가능
+        const { userId, level } = req.body;
+        const [data] = await BossRaidService.createId(userId, level); // raidRecordId 생성
+        const raidRecordId = data.insertId;
         await BossRaidService.putRaidRecordId(raidRecordId);
         isEntered = true;
+        return res.status(201).json({
+          message: "BossRaid Start!!",
+          isEntered,
+          raidRecordId,
+        });
       }
     } catch (err) {
       console.error(err);
       throw err;
     }
-
-    return res.status(201).json({
-      message: "BossRaid Start!!",
-      isEntered,
-      raidRecordId,
-    });
   }
 
   static async stopBossRaid(req, res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "cors": "^2.8.5",
+        "date-utils": "^1.2.21",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "http-errors": "^2.0.0",
@@ -223,6 +224,14 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/date-utils": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA==",
+      "engines": {
+        "node": ">0.4.0"
       }
     },
     "node_modules/debug": {
@@ -1096,6 +1105,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "date-utils": {
+      "version": "1.2.21",
+      "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
+      "integrity": "sha512-wJMBjqlwXR0Iv0wUo/lFbhSQ7MmG1hl36iuxuE91kW+5b5sWbase73manEqNH9sOLFAMG83B4ffNKq9/Iq0FVA=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "cors": "^2.8.5",
+    "date-utils": "^1.2.21",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "http-errors": "^2.0.0",

--- a/services/bossRaid.service.js
+++ b/services/bossRaid.service.js
@@ -109,7 +109,7 @@ class BossRaidService {
      * 기능: 게임 끝난 후 점수 합산을 위한 boss_raid_level 찾기 (boss_raid table)
      * 작성자: 이승연
      */
-    const sql = `SELECT user_id, boss_raid_level, enter_time FROM boss_raid WHERE raid_record_id=${raidRecordId}`;
+    const sql = `SELECT user_id, boss_raid_level, enter_time, end_time FROM boss_raid WHERE raid_record_id=${raidRecordId}`;
     let connection = null;
     try {
       connection = await mysqlPool.getConnection(async (conn) => conn);

--- a/services/bossRaid.service.js
+++ b/services/bossRaid.service.js
@@ -39,7 +39,7 @@ class BossRaidService {
     }
   }
 
-  static async putRaidRecordId(raidRecordId) {
+  static async putRaidRecordId(raidRecordId, bossRaidLimitSeconds) {
     /**
      * 기능: 게임 시작 가능시 raidStatus에 raidRecordId 넣기
      * 작성자: 이승연
@@ -48,6 +48,7 @@ class BossRaidService {
     try {
         await client.connect();
         await client.set("raidStatus", raidRecordId);
+        await client.expire("raidStatus", bossRaidLimitSeconds);  // 레이드 제한시간 지나면 raidStatus 삭제
     } catch {
         throw err;
     } finally {

--- a/utils/getStaticData.js
+++ b/utils/getStaticData.js
@@ -1,0 +1,25 @@
+const axios = require("axios");
+const BossRaidService = require("../services/bossRaid.service");
+
+const getStaticData = async () => {
+  let value = await BossRaidService.levelCahceToRedis();
+  let bossRaidLimitSeconds, levels;
+  if (value) {
+    bossRaidLimitSeconds = JSON.parse(value).bossRaids[0].bossRaidLimitSeconds;
+    levels = JSON.parse(value).bossRaids[0].levels;
+    console.log("from cached data");
+  } else {
+    const { data } = await axios.get(
+      "https://dmpilf5svl7rv.cloudfront.net/assignment/backend/bossRaidData.json"
+    );
+    await BossRaidService.putStaticData(JSON.stringify(data));
+    console.log("from source data");
+    bossRaidLimitSeconds = data.bossRaids[0].bossRaidLimitSeconds;
+    levels = data.bossRaids[0].levels;
+  }
+  return { 
+    bossRaidLimitSeconds: bossRaidLimitSeconds, 
+    levels: levels };
+}
+
+module.exports = getStaticData;


### PR DESCRIPTION
### PR 타입
- 기능 수정

### 반영 브랜치
- upgrade/raid_status_dapsu -> dev

### 변경 사항
- 보스레이드 시작 api 로직 수정: 게임 중인 유저가 있을 시 boss_raid 테이블에 데이터 생성되지 않도록 수정
- 보스레이드 종료 api 로직 수정
  - 레이드 제한시간 넘었을 때 raidStatus 데이터 지우도록 수정
  - api 여러 번 실행될 때 중복 처리되는 에러 수정
- staticData 메소드 utils 디렉토리로 분류
- 보스레이드 제한시간 지났을 때 raidStatus 자동으로 삭제되도록 설정